### PR TITLE
Add Linux support for tunnel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,30 @@ An example of one way to do this is in external_utun.py
 
 The code has been changed to suspend / resume remoted using an external c program via shell-out.
 
-Currently the project is designed only to run on MacOS. Some additional alterations will be
-needed to make it run on Linux. Windows is not an intended target.
+The project runs on both macOS and Linux. Windows is not an intended target.
+
+## Linux Support
+
+On Linux, the `tunnel` command (USB/lockdown path) is fully supported. The
+`remote-tunnel`, `remote-list`, and `remote-pair` commands require the
+[py_cf_iface](https://github.com/dryark/py_cf_iface) library to be ported
+to Linux as well (in progress).
+
+### Linux Requirements
+
+- `usbmuxd` running (for USB device communication)
+- `pytun-pmd3` Python package (installed automatically via requirements.txt)
+- `CAP_NET_ADMIN` capability or root privileges (for TUN interface creation)
+
+### Running on Linux
+
+```bash
+pip3 install -r requirements.txt
+
+# The tunnel command requires root or CAP_NET_ADMIN for TUN creation
+sudo python3 -m ios_rsd_tunnel tunnel -u <UDID>
+
+# Or grant capability to Python directly (avoids running as root):
+# sudo setcap cap_net_admin+ep $(readlink -f $(which python3))
+# python3 -m ios_rsd_tunnel tunnel -u <UDID>
+```

--- a/ios_rsd_tunnel/external_utun.py
+++ b/ios_rsd_tunnel/external_utun.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2021-2024 doronz <doron88@gmail.com>
 # Linux TUN backend using pytun_pmd3 (replaces macOS utunuds)
 import asyncio
+import logging
 import struct
+import subprocess
 import sys
 
 from socket import AF_INET6
@@ -17,6 +19,8 @@ else:
     UTUN_INET6_HEADER = b'\x00\x00\x86\xdd'
 
 UTUN_INET6_HEADER_SIZE = len(UTUN_INET6_HEADER)
+
+logger = logging.getLogger(__name__)
 
 
 class ExternalUtun:
@@ -38,9 +42,19 @@ class ExternalUtun:
     ) -> str:
         self.callback = incoming_data_callback
         self.tun = TunTapDevice()
-        self.tun.addr = ipv6
-        self.tun.up()
         self.name = self.tun.name
+
+        # Configure via ip commands (more reliable than ioctl for IPv6 on TUN)
+        subprocess.run(
+            ['ip', '-6', 'addr', 'add', f'{ipv6}/64', 'dev', self.name],
+            check=True,
+        )
+        subprocess.run(
+            ['ip', 'link', 'set', self.name, 'up'],
+            check=True,
+        )
+        logger.debug('TUN %s up with %s/64', self.name, ipv6)
+
         self._read_task = asyncio.create_task(
             self._tun_read_task(), name=f'tun-read-{label}'
         )
@@ -62,7 +76,6 @@ class ExternalUtun:
             self._read_task.cancel()
             self._read_task = None
         if self.tun:
-            self.tun.down()
             self.tun.close()
             self.tun = None
 

--- a/ios_rsd_tunnel/external_utun.py
+++ b/ios_rsd_tunnel/external_utun.py
@@ -1,54 +1,70 @@
 # Copyright (c) 2021-2024 doronz <doron88@gmail.com>
+# Linux TUN backend using pytun_pmd3 (replaces macOS utunuds)
+import asyncio
+import struct
+import sys
+
+from socket import AF_INET6
+from typing import Callable
+
 from pytun_pmd3 import TunTapDevice
 
-from typing import (
-    Callable,
-)
+IPV6_HEADER_SIZE = 40
 
-class ExternalUtun():
+if sys.platform == 'darwin':
+    UTUN_INET6_HEADER = struct.pack('>I', AF_INET6)
+else:
+    UTUN_INET6_HEADER = b'\x00\x00\x86\xdd'
+
+UTUN_INET6_HEADER_SIZE = len(UTUN_INET6_HEADER)
+
+
+class ExternalUtun:
     def __init__(self):
-        pass
-        
-    def write( self, data ):
-        self.tun.write( data )
-        pass
-    
-    @asyncio_print_traceback
-    async def tun_read_task(self) -> None:
-        read_size = self.tun.mtu + len(LOOPBACK_HEADER)
-        try:
-            async with aiofiles.open(self.tun.fileno(), 'rb', opener=lambda path, flags: path, buffering=0) as f:
-                while True:
-                    packet = await f.read(read_size)
-                    self.callback( packet )
-        except ConnectionResetError:
-            #self._logger.warning(f'got connection reset in {asyncio.current_task().get_name()}')
-            pass
-        except OSError:
-            #self._logger.warning(f'got oserror in {asyncio.current_task().get_name()}')
-            pass
-    
+        self.tun = None
+        self.name = ""
+        self._read_task = None
+        self.callback = None
+
+    def write(self, data):
+        if self.tun is not None:
+            self.tun.write(data)
+
     async def up(
         self,
-        label:str,
-        ipv6:str,
-        incoming_data_callback: Callable[[str], None]
+        label: str,
+        ipv6: str,
+        incoming_data_callback: Callable,
     ) -> str:
         self.callback = incoming_data_callback
         self.tun = TunTapDevice()
         self.tun.addr = ipv6
-        #self.tun.mtu = mtu
         self.tun.up()
-        self._tun_read_task = asyncio.create_task(self.tun_read_task(), name=f'tun-read-{address}')
-        
-        # Create a utun that is configured to receive traffic to the specified ipv6 range
-        # Receive data from the utun async, and call the callback when any comes in
-        return "utun3"
-    
-    # Shutdown the utun
+        self.name = self.tun.name
+        self._read_task = asyncio.create_task(
+            self._tun_read_task(), name=f'tun-read-{label}'
+        )
+        return self.name
+
+    async def _tun_read_task(self):
+        """Read IPv6 frames from TUN fd and dispatch via callback."""
+        loop = asyncio.get_event_loop()
+        while True:
+            data = await loop.run_in_executor(None, self.tun.read, 65535)
+            if not data:
+                break
+            if not data.startswith(UTUN_INET6_HEADER):
+                continue
+            await self.callback(data)
+
     def down(self) -> None:
-        self.tun.down()
-        pass
+        if self._read_task:
+            self._read_task.cancel()
+            self._read_task = None
+        if self.tun:
+            self.tun.down()
+            self.tun.close()
+            self.tun = None
 
     def __del__(self):
         self.down()

--- a/ios_rsd_tunnel/remote/remoted_tool.py
+++ b/ios_rsd_tunnel/remote/remoted_tool.py
@@ -2,6 +2,7 @@
 # License AGPL
 import logging
 import os
+import platform
 import shutil
 import subprocess
 
@@ -10,6 +11,11 @@ REMOTEDTOOL_PATH = ""
 logger = logging.getLogger(__name__)
 
 def validate_helpers() -> bool:
+    if platform.system() != 'Darwin':
+        # On Linux: no remotedtool/utunuds needed.
+        # TUN creation requires CAP_NET_ADMIN or root.
+        return True
+
     remotedtool_path = get_remotedtool_path()
     utunuds_path = get_utunuds_path()
 
@@ -78,12 +84,16 @@ def get_utunuds_path() -> str:
     return get_helper_path( "utunuds", "CFUTUNUDS", "CFTOOLS" )
 
 def stop_remoted() -> None:
+    if platform.system() != 'Darwin':
+        return
     bin = get_remotedtool_path()
     process = subprocess.Popen( [ bin, "suspend" ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True )
     _, stderr = process.communicate()
     logger.debug( "%s", stderr )
 
 def resume_remoted() -> None:
+    if platform.system() != 'Darwin':
+        return
     bin = get_remotedtool_path()
     process = subprocess.Popen( [ bin, "resume" ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True )
     _, stderr = process.communicate()

--- a/ios_rsd_tunnel/remote/tunnel.py
+++ b/ios_rsd_tunnel/remote/tunnel.py
@@ -10,7 +10,10 @@ import sys
 from abc import ABC, abstractmethod
 from asyncio import CancelledError, StreamReader, StreamWriter
 
-from cf_external_utun import ExternalUtun
+if sys.platform == 'darwin':
+    from cf_external_utun import ExternalUtun
+else:
+    from ..external_utun import ExternalUtun
 
 from construct import (
     Const,

--- a/ios_rsd_tunnel/remote/tunnel.py
+++ b/ios_rsd_tunnel/remote/tunnel.py
@@ -210,7 +210,11 @@ class RemoteTcpTunnel(RemoteTunnel):
                 self.tun.write(UTUN_INET6_HEADER + ipv6_header + ipv6_body)
         except (OSError, asyncio.exceptions.IncompleteReadError) as e:
             self._logger.warning(f'got {e.__class__.__name__} in {asyncio.current_task().get_name()}')
-            await self.wait_closed()
+            # Close the writer only — cannot await wait_closed() from within
+            # sock_read_task since wait_reader_closed() would await this task.
+            if not self._writer.is_closing():
+                self._writer.close()
+            await self.wait_writer_closed()
 
     def wait_closed_task(self):
         return self._writer.wait_closed()

--- a/ios_rsd_tunnel/remote/util.py
+++ b/ios_rsd_tunnel/remote/util.py
@@ -1,11 +1,18 @@
 # Copyright (c) 2024 Dry Ark LLC <license@dryark.com>
 # License AGPL 3.0
 from .remotexpc import RemoteXPCConnection
-from cf_mdns import (
-    get_remoted_interfaces,
-    get_service_info,
-)
-from cf_iface import get_potential_remoted_ifaces
+
+try:
+    from cf_mdns import (
+        get_remoted_interfaces,
+        get_service_info,
+    )
+    from cf_iface import get_potential_remoted_ifaces
+except ImportError:
+    # These are macOS-only; only needed for remote-* commands
+    get_remoted_interfaces = None
+    get_service_info = None
+    get_potential_remoted_ifaces = None
 from .remoted_tool import (
     stop_remoted,
     resume_remoted,

--- a/ios_rsd_tunnel/utils.py
+++ b/ios_rsd_tunnel/utils.py
@@ -50,7 +50,22 @@ def set_keepalive(
     if plat == 'Darwin':
         return _set_keepalive_darwin(sock, after_idle_sec, interval_sec, max_fails)
     
+    if plat == 'Linux':
+        return _set_keepalive_linux(sock, after_idle_sec, interval_sec, max_fails)
+
     raise RuntimeError(f'Unsupported platform {plat}')
+
+
+def _set_keepalive_linux(
+    sock: socket.socket,
+    after_idle_sec: int = DEFAULT_AFTER_IDLE_SEC,
+    interval_sec: int = DEFAULT_INTERVAL_SEC,
+    max_fails: int = DEFAULT_MAX_FAILS
+) -> None:
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, after_idle_sec)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, interval_sec)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, max_fails)
 
 
 def _set_keepalive_darwin(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ oscrypto==1.3.0
 PyNaCl==1.5.0
 qh3==1.0.4
 srptools==1.0.1
+pytun-pmd3>=2.0.0; sys_platform == "linux"


### PR DESCRIPTION
## Summary

- Rewrites `external_utun.py` with a working Linux TUN backend using `pytun_pmd3.TunTapDevice` for fd management + `ip` commands for interface configuration
- Adds platform-aware `ExternalUtun` import in `remote/tunnel.py` — uses `cf_external_utun` on macOS, built-in `external_utun` on Linux
- Adds Linux TCP keepalive support in `utils.py` using standard socket constants (`TCP_KEEPIDLE`, `TCP_KEEPINTVL`, `TCP_KEEPCNT`)
- Makes `remoted_tool.py` functions no-op on non-Darwin platforms (no `remotedtool`/`utunuds` on Linux)
- Guards `cf_mdns`/`cf_iface` imports in `remote/util.py` with try/except (macOS-only, pulled in transitively)
- Adds `pytun-pmd3` to `requirements.txt` with `sys_platform == "linux"` marker
- Fixes `RemoteTcpTunnel.sock_read_task` self-await crash on disconnect (pre-existing bug, all platforms)
- Updates README with Linux usage documentation

## Motivation

We're using py_ios_rsd_tunnel to establish RSD tunnels with iOS 17+ devices connected to Linux CI hosts (Fedora). The `tunnel` command (USB/lockdown path via usbmuxd) works cross-platform already at the protocol level — only the TUN creation and a few platform-specific helpers needed porting.

This is a minimal, focused change: the `remote-tunnel`, `remote-list`, and `remote-pair` commands still require macOS (they depend on `py_cf_iface` which needs its own Linux port). Only the `tunnel` command is being ported here.

## Technical details

- **TUN backend**: Uses `pytun_pmd3.TunTapDevice` to open `/dev/net/tun` and manage the fd. Interface configuration (IPv6 address, link up) uses `ip` commands via subprocess — the ioctl-based `.addr`/`.up()` methods in pytun_pmd3 silently fail for IPv6 on TUN devices.
- **PI header**: Linux TUN with default flags includes a 4-byte Protocol Information header (`\x00\x00\x86\xdd` for IPv6). The existing `UTUN_INET6_HEADER` in `remote/tunnel.py` already had the correct Linux branch.
- **Privilege model**: Requires `CAP_NET_ADMIN` or root for TUN creation, matching pymobiledevice3's requirements.
- **Shutdown fix**: `sock_read_task` previously called `wait_closed()` on disconnect, which called `wait_reader_closed()` → `await self._sock_read_task` — the current task awaiting itself (`RuntimeError`). Fixed to close the writer directly.
- **No macOS breakage**: All changes are gated on `platform.system()` or `sys.platform` checks. macOS behavior is completely unchanged (except the shutdown fix, which is cross-platform).

## Test plan

- [x] All modified files pass syntax check
- [x] Module imports work on Linux (`ExternalUtun`, `set_keepalive`, `validate_helpers`)
- [x] `validate_helpers()` returns `True` on Linux (skips macOS helper checks)
- [x] `stop_remoted()` / `resume_remoted()` are no-ops on Linux
- [x] End-to-end on Fedora 43 (kernel 6.18, Python 3.14):
  - `sudo python3 -m ios_rsd_tunnel tunnel -u <UDID>` with iPhone 14 via USB
  - TUN interface created, UP with correct IPv6/64 address
  - TCP connection to device RSD port: **success**
  - `pymobiledevice3 developer dvt ls --rsd <addr> <port> /` — listed device root filesystem through the tunnel
- [x] Clean shutdown: Ctrl+C exits cleanly with `INFO: tunnel was closed`, no tracebacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)